### PR TITLE
rfgb.utils.Data.setBackground() fix for data sets with multiple modes

### DIFF
--- a/rfgb/tests/rfgbtests/test_utils.py
+++ b/rfgb/tests/rfgbtests/test_utils.py
@@ -175,7 +175,7 @@ class UtilsTest(unittest.TestCase):
                                           'cancer(watson)': -0.5})
 
         # sampleData.literals should be an empty dictionary.
-        self.assertEqual(sampleData.literals, {})
+        self.assertEqual(sampleData.literals, [])
 
         # Test some of the Data object functions, they should not
         # mutate contents.

--- a/rfgb/tree.py
+++ b/rfgb/tree.py
@@ -145,13 +145,19 @@ class node(object):
         bestTest = "" #initalize best test to empty string
         bestTExamples = [] #list for best test examples that satisfy clause
         bestFExamples = [] #list for best test examples that don't satisfy clause
-        literals = data.getLiterals() #get all the literals that the data (facts) contains
+        # Get all literals that the data (facts) contain
+        literals = data.getLiterals()
+
         tests = []
-        for literal in literals: #for every literal generate test conditions
-            literalName = literal
-            literalTypeSpecification = literals[literal]
-            tests += Logic.generateTests(literalName,literalTypeSpecification,clause) #generate all possible literal, variable and constant combinations
-        if self.parent!="root":
+        # For each literal, generate test conditions.
+        for literal in literals:
+            literalName = literal[0]
+            literalTypeSpecification = literal[1]
+
+            # Generate all possible literal, variable, and constant combinations
+            tests += Logic.generateTests(literalName,literalTypeSpecification,clause)
+
+        if self.parent != "root":
                 tests = [test for test in tests if not test in ancestorTests]
         tests = set(tests)
 

--- a/rfgb/utils.py
+++ b/rfgb/utils.py
@@ -55,6 +55,7 @@ class Data(object):
         self.examplesTrueValue = {}
         self.target = None
         self.literals = []
+        self.literalTypes = {}
         self.variableType = {}
 
         self.softm = softm
@@ -205,6 +206,7 @@ class Data(object):
         for literalBk in bkWithoutTargets:
             literalName = literalBk.split('(')[0]
             literalTypeSpecification = literalBk[:-1].split('(')[1].split(',')
+            self.literalTypes[literalName] = literalTypeSpecification
             self.literals.append([literalName, literalTypeSpecification])
 
     def getLiterals(self):

--- a/rfgb/utils.py
+++ b/rfgb/utils.py
@@ -54,7 +54,7 @@ class Data(object):
         self.examples = {}
         self.examplesTrueValue = {}
         self.target = None
-        self.literals = {}
+        self.literals = []
         self.variableType = {}
 
         self.softm = softm
@@ -205,7 +205,7 @@ class Data(object):
         for literalBk in bkWithoutTargets:
             literalName = literalBk.split('(')[0]
             literalTypeSpecification = literalBk[:-1].split('(')[1].split(',')
-            self.literals[literalName] = literalTypeSpecification
+            self.literals.append([literalName, literalTypeSpecification])
 
     def getLiterals(self):
         '''gets all the literals in the facts'''

--- a/rfgb/utils.py
+++ b/rfgb/utils.py
@@ -273,12 +273,25 @@ class Utils(object):
 
     @staticmethod
     def addVariableTypes(literal):
-        '''adds type of variables contained in literal'''
-        literalName = literal.split('(')[0] #get literal name
-        literalTypeSpecification = Utils.data.literals[literalName] #get background info
-        literalArguments = literal[:-1].split('(')[1].split(',') #get arguments
-        numberOfArguments = len(literalArguments)
-        for i in range(numberOfArguments):
+        """
+        As literals are encountered, update Utils.data.variableType with the
+        type of the variables encountered.
+
+        :param literal: A literal of the form smokes(W) or friends(A,B)
+        :type literal: str.
+        """
+
+        # Get the name of the literal.
+        literalName =  literal.split('(')[0]
+
+        # Get background info for the literal
+        literalTypeSpecification = Utils.data.literalTypes[literalName]
+
+        # Get the arguments
+        literalArguments = literal[:-1].split('(')[1].split(',')
+
+        # Get the number of arguments.
+        for i in range(len(literalArguments)):
             if literalTypeSpecification[i][0]!='[':
                 variable = literalArguments[i]
                 if variable not in Utils.data.variableType.keys():


### PR DESCRIPTION
This is a possible resolution to Issue #10.

Rather than `rfgb.utils.Data` containing `literals = {}`, this value is split into a list and a dictionary:

```diff
-        self.literals = {}
+        self.literals = []
+        self.literalTypes = {}
```

The list may be used to store a literal and its associated mode definition. For example, in the ToyCancer data set, `self.literals = [['friends', ['+person', '-person']], ['friends', ['-person', '+person']], ['smokes', ['+person']]]`, rather than a dictionary where the most-recently-seen value is set to the the value used.

---

* Resolving this required adjusting a test case, but the existing test case checked whether the initialized literals was an empty dictionary.