### PR TITLE
Solution for issue #7 and issue #8

### DIFF
--- a/rfgb/boosting.py
+++ b/rfgb/boosting.py
@@ -32,7 +32,7 @@ from math import log
 from math import exp
 from copy import deepcopy
 
-__logPrior__ = log(0.5/float(1-0.5))
+__logPrior__ = -1.8
 
 """
 class Boosting(object):
@@ -134,7 +134,7 @@ def performInference(testData, trees):
     if not testData.regression:
 
         # Initialize log odds of assumed prior probability for example.
-        logPrior = log(0.5/float(1-0.5))
+        
         for example in testData.pos:
 
             # Compute sum of gradients
@@ -152,6 +152,7 @@ def performInference(testData, trees):
             testData.neg[example] = Utils.sigmoid(logPrior + sumOfGradients)
 
     elif testData.regression:
+        logPrior = 0.0
         for example in testData.examples:
             sumOfGradients = computeSumOfGradients(example, trees, testData)
             testData.examples[example] = sumOfGradients

--- a/rfgb/utils.py
+++ b/rfgb/utils.py
@@ -85,7 +85,7 @@ class Data(object):
         for example in pos:
             if example.split('(')[0] == target:
                 # Set initial gradient to 0.5 for positives.
-                self.pos[example] = 0.5
+                self.pos[example] = 1-Utils.sigmoid(-1.8)
 
     def setExamples(self, examples, target):
         """
@@ -109,7 +109,7 @@ class Data(object):
         for example in neg:
             if example.split('(')[0] == target:
                 # Set initial gradient to -0.5 for negative examples.
-                self.neg[example] = -0.5
+                self.neg[example] = -Utils.sigmoid(-1.8)
 
     def setTarget(self, bk, target):
         """


### PR DESCRIPTION
This pull request resolve these two issues. 

* `rfgb/boosting.py` replace the `logPrior` with `-1.8` since the default function is the classification. Since regression is also an option, in that case the `logPrior` is `0`.

* `rfgb/utils.py` replace the initial values with correct ones.

